### PR TITLE
Update base image to resolve vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.21.1-alpine
+FROM nginx:1.21.5-alpine
 
 ENV NGINX_ENVSUBST_OUTPUT_DIR /tmp
 ENV PROXY_LISTEN_PORT 8443


### PR DESCRIPTION
What:
update base version to fix vulns described in a `docker scan eknert/nginx-tls-terminator`

Why:
the current version does not pass a `docker scan`, due to vulnerabilities in the base image.

Testing:
1.  build image with new Dockerfile
2. `docker tag {container ID}  eknert/nginx-tls-terminator:1.21.5-alpine`
3. `docker scan -f ./Dockerfile eknert/nginx-tls-terminator:1.21.5-alpine`
``` text
Testing eknert/nginx-tls-terminator:1.21.5-alpine...

Package manager:   apk
Target file:       ./Dockerfile
Project name:      docker-image|eknert/nginx-tls-terminator
Docker image:      eknert/nginx-tls-terminator:1.21.5-alpine
Platform:          linux/amd64
Base image:        nginx:1.21.5-alpine

✔ Tested 43 dependencies for known vulnerabilities, no vulnerable paths found.

According to our scan, you are currently using the most secure version of the selected base image

For more free scans that keep your images secure, sign up to Snyk at https://dockr.ly/3ePqVcp

```